### PR TITLE
set the shellcheck as editable from the UI

### DIFF
--- a/ansible_collections/axonops/configuration/plugins/modules/shell_check.py
+++ b/ansible_collections/axonops/configuration/plugins/modules/shell_check.py
@@ -175,7 +175,7 @@ def run_module():
         module.exit_json(**result)
         return
 
-    new_check['readonly'] = True
+    new_check['readonly'] = False
 
     new_check['integrations'] = {
         'OverrideError': False,


### PR DESCRIPTION
As we create shell-checks with this tool right now. We set them to not be editable in the user interface but only to be editable by a script like this using the API. This change will disable the read-only allowing the shell check to be editable by any allowed user using the user interface. 