### PR TITLE
set AXONOPS_ORG as mandatory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 check-env:
 	@echo $(ANSIBLE_COLLECTIONS_PATH)
-	@if [ ! "$(AXONOPS_TOKEN)" ]; then echo "$(BOLD)$(RED)AXONOPS_TOKEN is not set$(RESET)"; exit 1;fi
+	@if [ ! "$(AXONOPS_ORG)" ]; then echo "$(BOLD)$(RED)AXONOPS_ORG is not set$(RESET)"; exit 1;fi
 
 
 check: ## run pre-commit tests

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ export AXONOPS_ORG='example'
 export AXONOPS_TOKEN='aaaabbbbccccddddeeee'
 ```
 
-To make the process easier the file `export_tokens.sh` was created with all the accepted variables.
-Modify the file with your details and exports them with
+To simplify the process, the `export_tokens.sh` file has been created with all the accepted variables. Modify this file with your specific details, and then export the variables.
 
 ```commandline
 source ./export_tokens.sh
 ```
 
-See the file itself for more details on the accepted environment variables
+The `AXONOPS_TOKEN` parameter is used only for AxonOps SaaS. For AxonOps on-premises, you can use a username and password or configure it to allow anonymous login. 
+Refer to `export_tokens.sh` for more information on configuring the Ansible Playbook for AxonOps on-premises and on the accepted environment variables.
 
 ### Ansible preparation
 


### PR DESCRIPTION

The AXONOPS_TOKEN is mandatory only on SaaS when we use it, but we can use anonymous or user/password authentication on-prem and locally. This makes AXONOPS_TOKEN not mandatory.

At the same time, AXONOPS_ORG is mandatory because it is present and necessary for all our platforms and is required in many APIs.
