### PR TITLE
set channel as optional

### DIFF
--- a/setup_alert_endpoints.yml
+++ b/setup_alert_endpoints.yml
@@ -63,7 +63,7 @@
         cluster: "{{ cluster }}"
         name: "{{ item.name }}"
         webhook_url: "{{ item.webhook_url }}"
-        channel: "{{ item.channel }}"
+        channel: "{{ item.channel|default(omit) }}"
       when: axonops_slack_integration is defined
       with_items:
         "{{ axonops_slack_integration }}"


### PR DESCRIPTION
The Slack channel is optional in AxonOps, if the user doesn't specify it, the default channel will be used. 