### PR TITLE
add match for escaped characters

### DIFF
--- a/ansible_collections/axonops/configuration/plugins/modules/log_alert_rule.py
+++ b/ansible_collections/axonops/configuration/plugins/modules/log_alert_rule.py
@@ -226,7 +226,7 @@ def run_module():
     # If it is an old alert, read it
     if old_alert:
         pattern = r'events\{(.+)\}'
-        pattern_element = r'(.+?)="(.+?)"'
+        pattern_element = r'(.+?)="((?:[^"\\]|\\.)*?)"'
         match = re.search(pattern, old_alert['expr'])
         old_alert_expr = {}
         if match:
@@ -235,9 +235,9 @@ def run_module():
                 if match_element:
                     old_alert_expr[match_element.group(1)] = match_element.group(2).replace('|', ',')
                 else:
-                    module.fail_json(msg=r'pattern not found for expr element')
+                    module.fail_json(msg=r'pattern not found for expr element ' + element)
         else:
-            module.fail_json(msg=r'pattern not found for expr')
+            module.fail_json(msg=r'pattern not found for expr ' + old_alert['expr'])
 
         old_data = {
             'name': old_alert['alert'],


### PR DESCRIPTION
This PR fixes the issue with double quotes in the `content` parameter, which is not read properly from the API and results in an empty or incomplete field.

e.g `content: \"is now DOWN\"` is seen as `content: \\\`

The escaped double quote `\"` is taken from the non-greedy regular expression `r'(.+?)="(.+?)"'` as the end of the value, the second parameter. With this change, the regular expression will also include the escaped characters, like
```
test_strings = [
    'name="value"',
    'message="\"Corrupt table\""',
    'key="value with \"escaped quotes\""'
]
```
 