### PR TITLE
Fix slack channel parameter

### DIFF
--- a/ansible_collections/axonops/configuration/plugins/modules/slack_integration.py
+++ b/ansible_collections/axonops/configuration/plugins/modules/slack_integration.py
@@ -76,7 +76,7 @@ def run_module():
     module_args = make_module_args({
         'name': {'type': 'str', 'required': True},
         'webhook_url': {'type': 'str'},
-        'channel': {'type': 'str'},
+        'channel': {'type': 'str', 'required': False, 'default': ''},
         'present': {'type': 'bool', 'default': True},
         'axonops_url': {'type': 'str', 'required': False, 'default': ''},
     })

--- a/setup_alert_endpoints.yml
+++ b/setup_alert_endpoints.yml
@@ -65,6 +65,7 @@
         name: "{{ item.name }}"
         webhook_url: "{{ item.webhook_url }}"
         channel: "{{ item.channel|default(omit) }}"
+        present: "{{ item.present|default(true) }}"
       when: axonops_slack_integration is defined
       no_log: "{{ false if enable_logging is defined and enable_logging else true }}"
       with_items:


### PR DESCRIPTION
If a default parameter is not specified the `channel` parameter will be sent as `null`, AxonOps do not recognise this, the default needs to be `''` (empty string) 