### PR TITLE
fix remove unused parameters

### DIFF
--- a/ansible_collections/axonops/configuration/plugins/modules/alert_rule.py
+++ b/ansible_collections/axonops/configuration/plugins/modules/alert_rule.py
@@ -349,9 +349,6 @@ def run_module():
             })
     if routing:
         new_data['integrations']['Routing'] = routing
-        new_data['integrations']['OverrideError'] = True
-        new_data['integrations']['OverrideInfo'] = True
-        new_data['integrations']['OverrideWarning'] = True
     elif 'integrations' in new_data:
         new_data['integrations']['Routing'] = []
 
@@ -496,7 +493,6 @@ def run_module():
     _, error = axonops.do_request(rel_url=alerts_url, method='POST', json_data=payload)
     if error is not None:
         module.fail_json(msg="Failed to create alert rule: " + str(payload), **result)
-        module.f
         return
 
     module.exit_json(**result)


### PR DESCRIPTION
The parameters
```
 new_data['integrations']['OverrideError'] = True
 new_data['integrations']['OverrideInfo'] = True
 new_data['integrations']['OverrideWarning'] = True
 ``` 
Are not evaluated by the server. The server uses the `Routing` to understand if a route has been overridden: if a route is present, the route's severity is used to determine which route has been overridden.  