### PR TITLE
set help as default for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,15 @@ else
 PIPENVCMD=
 endif
 
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 check-env:
 	@echo $(ANSIBLE_COLLECTIONS_PATH)
 	@if [ ! "$(AXONOPS_ORG)" ]; then echo "$(BOLD)$(RED)AXONOPS_ORG is not set$(RESET)"; exit 1;fi
 
-
 check: ## run pre-commit tests
 	@${PIPENVCMD} pre-commit run --all-files
-
-help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 endpoints: check-env ## Create alert endpoints and integrations
 	@${PIPENVCMD} ansible-playbook -i localhost, setup_alert_endpoints.yml --diff ${EXTRA}


### PR DESCRIPTION
This PR sets the help section of the Makefile as first, making it the default behavior of `make`: 

before this change:

``` BASH
$ make                        
./
$ make help
backups                        Create backup
check                          run pre-commit tests
endpoints                      Create alert endpoints and integrations
log-alerts                     Create alerts based on logs
metrics-alerts                 Create alerts based on metrics
routes                         Create alert routes
service-checks                 Create alerts for TCP and shell connections
```

with the change:

``` BASH
$ make     
backups                        Create backup
check                          run pre-commit tests
endpoints                      Create alert endpoints and integrations
log-alerts                     Create alerts based on logs
metrics-alerts                 Create alerts based on metrics
routes                         Create alert routes
service-checks                 Create alerts for TCP and shell connections
$ make help
backups                        Create backup
check                          run pre-commit tests
endpoints                      Create alert endpoints and integrations
log-alerts                     Create alerts based on logs
metrics-alerts                 Create alerts based on metrics
routes                         Create alert routes
service-checks                 Create alerts for TCP and shell connections
```
