### PR TITLE
remove default url override in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CURRENT_FOLDER=$(shell basename "$$(pwd)")
 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 UNAME=$(shell uname -s)
 ANSIBLE_COLLECTIONS_PATH=./
-AXONOPS_URL ?= https://dash.axonops.cloud
 
 # Default to use pipenv unless disabled
 PIPENV ?= false

--- a/make.sh
+++ b/make.sh
@@ -3,7 +3,6 @@
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 export UNAME=$(uname -s)
 export ANSIBLE_COLLECTIONS_PATH=./
-export AXONOPS_URL=${AXONOPS_URL:-https://dash.axonops.cloud}
 
 # Default to use pipenv unless disabled
 if [[ "${PIPENV}" == "true" ]]; then


### PR DESCRIPTION
The AxonOps ansible module can manage the default URL to SAAS and the eventual override to on-prem by itself. 

This Makefile parameter is a force override to `https://dash.axonops.cloud` if the variable `AXONOPS_URL` is not set. This creates an issue with SAAS as it doesn't add the ORG parameter.